### PR TITLE
 bad smell : Speculative Generality

### DIFF
--- a/Refactoring/src/main/java/ch/heigvd/gen2019/OrdersWriter.java
+++ b/Refactoring/src/main/java/ch/heigvd/gen2019/OrdersWriter.java
@@ -30,7 +30,7 @@ public class OrdersWriter {
 
                 if (product.getSize() != Size.SIZE_NOT_APPLICABLE) {
                     sb.append("\"size\": \"");
-                    sb.append(getSizeFor(product));
+                    sb.append(product.getSize());
                     sb.append("\", ");
                 }
 


### PR DESCRIPTION
> In class OrdersWriter method getSizeFor() only call product.getSize()
why don't directly call product.getSize()?
refractoring technic : Inline Method
fixes #14