### PR TITLE
Pull Up Method

### DIFF
--- a/Refactoring/src/main/java/ch/heigvd/gen2019/Size.java
+++ b/Refactoring/src/main/java/ch/heigvd/gen2019/Size.java
@@ -1,48 +1,12 @@
 package ch.heigvd.gen2019;
 
 public enum Size {
-    XS {
-        @Override
-        public String toString() {
-            return "XS";
-        }
-    },
-    S {
-        @Override
-        public String toString() {
-            return "S";
-        }
-    },
-    M {
-        @Override
-        public String toString() {
-            return "M";
-        }
-    },
-    L {
-        @Override
-        public String toString() {
-            return "L";
-        }
-    },
-    XL {
-        @Override
-        public String toString() {
-            return "XL";
-        }
-    },
-    XXL {
-        @Override
-        public String toString() {
-            return "XXL";
-        }
-    },
-    SIZE_NOT_APPLICABLE {
-        @Override
-        public String toString() {
-            return "Invalid Size";
-        }
-    };
+    XS,
+    S,
+    M,
+    L,
+    XL,
+    XXL,
+    SIZE_NOT_APPLICABLE
 
-    public abstract String toString();
 }


### PR DESCRIPTION
In enum Size we can use the default implementation of toString because object name enum = stringification of this object
fixes #18 